### PR TITLE
Add a compute shader sample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +257,12 @@ dependencies = [
  "libloading 0.8.1",
  "winapi",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -309,6 +328,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_06_gol"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "gif",
+ "indicatif",
+ "pollster",
+ "rand",
+ "wgpu",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +396,27 @@ dependencies = [
  "log",
  "rustversion",
  "windows 0.48.0",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -506,6 +558,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -682,6 +756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +868,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +907,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1116,6 +1238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1318,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
@@ -1369,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "example_03_obj",
     "example_04_depth",
     "example_05_camera",
+    "example_06_gol",
 ]

--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ We reuse the bunny OBJ from the previous example,
 except this time we provide camera parameters to the vertex shader with uniform buffers
 to perform a perspective projection instead of a simple orthogonal projection.
 In addition, we also introduce the notion of near/far planes to control Z clipping.
+
+## 6. Storage texture and Compute shader
+
+This example shows how to use a compute shader to evolve a game of life automaton. Contrary to vertex and fragment shaders, compute shaders have no predefined outputs; here we use a "storage texture" to write the next state of the automaton. A grid of workgroups (which is itself a grid of threads) is dispatched so that one thread is assigned to one cell (i.e. one pixel of the input texture).
+A more advanced variant of the compute shader illustrates how to use local workgroup memory, which is faster than video or system memory.

--- a/example_06_gol/Cargo.toml
+++ b/example_06_gol/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "example_06_gol"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wgpu = "0.19.1"    # Rust library for WebGPU
+pollster = "0.3.0" # Simplest dep for async main
+# Cast Rust structs to u8 buffers
+bytemuck = { version = "1.14.1", features = ["derive"] }
+gif = "0.13.1" # Save generated sequence as gif
+indicatif = "0.17.8" # Show a console progress bar
+rand = "0.8.5"

--- a/example_06_gol/src/game_of_life.wgsl
+++ b/example_06_gol/src/game_of_life.wgsl
@@ -18,9 +18,7 @@
 // (comparatively slow) VRAM
 @compute
 @workgroup_size(16, 16)
-fn step(@builtin(global_invocation_id) cell_id: vec3u,
-        @builtin(local_invocation_id) local_id: vec3u,
-) {
+fn step(@builtin(global_invocation_id) cell_id: vec3u) {
 
     var num_alive = 0;
     var alive: bool = false;
@@ -38,7 +36,6 @@ fn step(@builtin(global_invocation_id) cell_id: vec3u,
             }
         }
     }
-    let num_dead = 8 - num_alive;
 
     if alive {
         if (num_alive < 2) || (num_alive > 3) {
@@ -120,7 +117,6 @@ fn step_local_mem(@builtin(global_invocation_id) cell_id: vec3u,
             }
         }
     }
-    let num_dead = 8 - num_alive;
 
     if alive {
         if (num_alive < 2) || (num_alive > 3) {

--- a/example_06_gol/src/game_of_life.wgsl
+++ b/example_06_gol/src/game_of_life.wgsl
@@ -1,0 +1,138 @@
+// Compute shader that computes Conway's game of life rules for each thread/cell
+//
+// Note 1: we can't use 2 storage textures, one with read access, the other with write access,
+// because currently the Rust implementation of webgpu does not support read-only nor read-write
+// storage textures of any format (r32uint should be supported as per the WebGPU spec).
+// Instead we use a regular texture as input.
+// Note 2: 32 bits uint is very wastefull for storing a cell's binary liveliness, but storage
+// textures are limited in their format. In a more performance minded setting we could pack
+// 32 cells in a single texel.
+// Note 3: there are 2 functionnaly equivalent entry points in this file, adapt the pipeline
+// creation to select the one you want to use
+
+@group(0) @binding(0) var input_grid: texture_2d<u32>;
+@group(0) @binding(1) var output_grid: texture_storage_2d<r32uint, write>;
+
+// This is a basic variant that reads directly into the input texture
+// Because each threads access its 3x3 neighbnorhood, this implies redundant accesses to
+// (comparatively slow) VRAM
+@compute
+@workgroup_size(16, 16)
+fn step(@builtin(global_invocation_id) cell_id: vec3u,
+        @builtin(local_invocation_id) local_id: vec3u,
+) {
+
+    var num_alive = 0;
+    var alive: bool = false;
+    for (var i = -1; i <= 1; i++) {
+        for (var j = -1; j <= 1; j++) {
+            let cell = textureLoad(input_grid, (vec2i(cell_id.xy) + vec2i(j, i)) % vec2i(textureDimensions(input_grid)), 0).x;
+            if (i == 0) && (j == 0) {
+                if cell > 0 {
+                    alive = true;
+                }
+            } else {
+                if cell > 0 {
+                   num_alive++;
+                }
+            }
+        }
+    }
+    let num_dead = 8 - num_alive;
+
+    if alive {
+        if (num_alive < 2) || (num_alive > 3) {
+            alive = false;
+        } else {
+            alive = true;
+        } 
+    } else if num_alive == 3 {
+        alive = true;
+    }
+
+    textureStore(output_grid, cell_id.xy, vec4u(select(0, 1, alive)));
+}
+
+// This variant uses local workgroup memory which is faster thatn VRAM (closer in speed to an L1 cache).
+// The threads in the workgroup cooperatively load the cells necessary for their computations into
+// an array declared in the workgroup address space.
+// This variable is common to all threads in the workgroup. Here we just access it for reading,
+// otherwise concurrent accesses should be taken care of (e.g. using atomic operations).
+
+// array<bool> would be better, but it does not seem to work
+var<workgroup> grid: array<u32, 324>; // (1+16+1)x(1+16+1) = 18x18
+
+@compute
+@workgroup_size(16, 16)
+fn step_local_mem(@builtin(global_invocation_id) cell_id: vec3u,
+        @builtin(local_invocation_id) local_id: vec3u,
+) {
+    let width = textureDimensions(input_grid).x;
+    let height = textureDimensions(input_grid).y;
+    // Every thread loads its cell
+    grid[18 * (local_id.y + 1) + (local_id.x + 1)] = textureLoad(input_grid, vec2i(cell_id.xy), 0).x;
+
+    // Top threads also load an extra line above
+    if (local_id.y == 0) {
+        grid[local_id.x + 1] = textureLoad(input_grid, vec2i(i32(cell_id.x), i32((cell_id.y - 1) % height)), 0).x;
+        if (local_id.x == 0) {
+            grid[0] = textureLoad(input_grid, vec2i(i32((cell_id.x - 1) % width), i32((cell_id.y - 1) % height)), 0).x;
+        } else if (local_id.x == 15) {
+            grid[17] = textureLoad(input_grid, vec2i(i32((cell_id.x + 1) % width), i32((cell_id.y - 1) % height)), 0).x;
+        }
+    }
+    // Bottom threads load an extra line below
+    else if (local_id.y == 15) {
+        grid[18 * 17 + local_id.x + 1] = textureLoad(input_grid, vec2i(i32(cell_id.x), i32((cell_id.y + 1) % height)), 0).x;
+        if (local_id.x == 0) {
+            grid[18 * 17] = textureLoad(input_grid, vec2i(i32((cell_id.x - 1) % width), i32((cell_id.y + 1) % height)), 0).x;
+        } else if (local_id.x == 15) {
+            grid[18 * 17 + 17] = textureLoad(input_grid, vec2i(i32((cell_id.x + 1) % width), i32((cell_id.y + 1) % height)), 0).x;
+        }
+    }
+    // Left side threads load an extra cell to the left
+    else if (local_id.x == 0) {
+        grid[18 * local_id.y] = textureLoad(input_grid, vec2i(i32((cell_id.x - 1) % width), i32(cell_id.y)), 0).x;
+    }
+    // Right side threads load an extra cell to the right
+    else if (local_id.x == 15) {
+        grid[18 * local_id.y + 17] = textureLoad(input_grid, vec2i(i32((cell_id.x + 1) % width), i32(cell_id.y)), 0).x;
+    }
+
+    // Wait for each thread to have loaded its data
+    workgroupBarrier();
+
+    // The rest is similar to the other variant
+    let cell_coord = vec2i(local_id.xy + vec2u(1, 1));
+    var num_alive = 0;
+    var alive: bool = false;
+    for (var i = -1; i <= 1; i++) {
+        for (var j = -1; j <= 1; j++) {
+            let cell = grid[18 * (cell_coord.y + i) + (cell_coord.x + j)];
+            if (i == 0) && (j == 0) {
+                if cell > 0 {
+                    alive = true;
+                }
+            } else {
+                if cell > 0 {
+                   num_alive++;
+                }
+            }
+        }
+    }
+    let num_dead = 8 - num_alive;
+
+    if alive {
+        if (num_alive < 2) || (num_alive > 3) {
+            alive = false;
+        } else {
+            alive = true;
+        } 
+    } else if num_alive == 3 {
+        alive = true;
+    }
+
+    textureStore(output_grid, cell_id.xy, vec4u(select(0, 1, alive)));
+}
+
+

--- a/example_06_gol/src/main.rs
+++ b/example_06_gol/src/main.rs
@@ -145,8 +145,10 @@ async fn run() {
 
     // Animated gif encoder
     let mut image = File::create("image.gif").unwrap();
-    let color_map = &[0x11, 0x77, 0xaa, /* cell color */
-                      0x33, 0x22, 0,    /* background color*/ ];
+    let color_map = &[
+        0x11, 0x77, 0xaa, /* cell color */
+        0x33, 0x22, 0, /* background color*/
+    ];
     let mut gif_enc =
         gif::Encoder::new(&mut image, width as u16, height as u16, color_map).unwrap();
 

--- a/example_06_gol/src/main.rs
+++ b/example_06_gol/src/main.rs
@@ -1,0 +1,347 @@
+//! This example shows how to use a compute shader to evaluate a simple function in parallel
+//! on a set of data.
+//!
+//! The function is the ruleset of Conway's Game of Life. It is defined on a 3x3 neighborhood
+//! of pixels (or cells) from a larger grid. Its output is the new value of the center pixel/cell.
+//! We use a compute shader to apply the function at all pixel locations of an input image,
+//! producing a new image representing the next state of the cellular automaton.
+//! We iterate the process a few times to capture the automaton evolution, each time swapping
+//! the input and output images.
+//!
+//! This sample demonstrates:
+//! * The use of compute shader that writes into a storage texture
+//! * The classic "ping-pong" technique between two textures for iterative computation
+//! * The use of local workgroup memory (optional: see the shader code for details)
+//!
+//! 1. (async) Initialize the connection with the GPU device
+//! 2. Initialize 2 wgpu Texture objects that will serve as input and output data to a compute shader
+//!    To be able to write to these textures from a computer shader, their declaration includes
+//!    "storage binding" as usage (as well as "texture binding", for reading them)
+//! 3. Place cells at random locations into the first input grid (initial automaton state)
+//!    and upload this data int the respective texture.
+//! 4. Initialize a wgpu Buffer where one of the texture will be transferred to
+//! 5. Load the shader module, containing a compute shader
+//! 6. Define a compute pipeline
+//! 7. Create two similar bind groups:
+//!    - one that binds texture 0 as input and texture 1 as output
+//!    - the other, similar but with bindings swapped
+//! 8. Iterate multiple run of our compute shader
+//!    1. dispatch a grid of workgroups running the computer kernel to cover the whole grid
+//!    2. copy the current input grid into the staging buffer
+//!    3. submit the commands to the queue
+//!    4. read back the content of the staging buffer
+//!    5. postprocess the pixel data to encode a frame in an animated gif
+//!    6. unmap the staging buffer so that it's reusable for next iteration
+
+use rand::prelude::*;
+use std::borrow::Cow;
+use std::fs::File;
+
+fn main() {
+    // Make the main async
+    pollster::block_on(run());
+}
+
+async fn run() {
+    // (1) Initializing WebGPU
+    println!("Initializing WebGPU ...");
+    let (device, queue) = init_wgpu_device().await.unwrap();
+
+    // (2) Initialize two textures for the input (current state) and output (next state) grids
+    let width = 256;
+    let height = 256;
+    let grids = [
+        init_grid_texture(&device, width, height),
+        init_grid_texture(&device, width, height),
+    ];
+    let desc = wgpu::TextureViewDescriptor {
+        label: None,
+        format: None,
+        dimension: None,
+        aspect: wgpu::TextureAspect::All,
+        base_mip_level: 0,
+        mip_level_count: Some(1),
+        base_array_layer: 0,
+        array_layer_count: Some(1),
+    };
+    let grid_views = [grids[0].create_view(&desc), grids[1].create_view(&desc)];
+
+    // (3) Put some initial random cells into the input grid
+    let mut rng = rand::thread_rng();
+    let init_state: Vec<u8> = (0..4 * width * height)
+        .map(|i| {
+            if rng.gen::<u8>() > 200 && (i % 4 == 0) {
+                1
+            } else {
+                0
+            }
+        })
+        .collect();
+    queue.write_texture(
+        wgpu::ImageCopyTexture {
+            texture: &grids[0],
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &init_state,
+        wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(4 * width), // texel size of r32uint texture is 4 bytes
+            rows_per_image: Some(height),
+        },
+        grids[0].size(),
+    );
+
+    // (4) Create a staging buffer for retrieving the content of the current state texture
+    let staging_buffer = init_buffer(&device, width, height);
+
+    // (5) Initialize the shader module, containing a single computer shader
+    let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Game of Life"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("game_of_life.wgsl").into()),
+    });
+
+    // (6) Define a compute pipeline
+    // Use "step" or "step_local_mem" as the entry point of the shader.
+    let pipeline = build_pipeline(&device, &shader_module, "step");
+
+    // (7) create two bind groups alternating the role of the 2 textures
+    let desc = wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&grid_views[0]),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&grid_views[1]),
+            },
+        ],
+    };
+    let desc_alt = wgpu::BindGroupDescriptor {
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&grid_views[1]),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&grid_views[0]),
+            },
+        ],
+        ..desc
+    };
+    let bind_groups = [
+        device.create_bind_group(&desc),
+        device.create_bind_group(&desc_alt),
+    ];
+
+    // Show progress in the console
+    const N_ITERS: usize = 1000;
+    let bar = indicatif::ProgressBar::new(N_ITERS as u64);
+
+    // Animated gif encoder
+    let mut image = File::create("image.gif").unwrap();
+    let color_map = &[0x11, 0x77, 0xaa, /* cell color */
+                      0x33, 0x22, 0,    /* background color*/ ];
+    let mut gif_enc =
+        gif::Encoder::new(&mut image, width as u16, height as u16, color_map).unwrap();
+
+    // (8) Evolve the automaton over some iterations
+    println!("Computing Game of Life's iterations ...");
+    for i in 0..N_ITERS {
+        bar.inc(1);
+
+        // Initialize a command encoder
+        let mut encoder = device.create_command_encoder(&Default::default());
+
+        // (8.1) launch the compute kernel in blocks
+        launch_kernel(
+            &mut encoder,
+            &pipeline,
+            &bind_groups[i % 2], // alternate input and output grids every other iteration
+            &grids[0].size(),
+        );
+
+        // (8.2) Copy the current input texture to the staging buffer
+        copy_texture_to_buffer(&mut encoder, &grids[i % 2], &staging_buffer);
+
+        // (8.3) Finalize the command encoder and send it to the queue
+        queue.submit(Some(encoder.finish()));
+
+        // (8.4) read back the content of the staging buffer
+        let data = readback_buffer_data(&device, &staging_buffer).await;
+
+        // (8.5) Convert the returned data and encode it as frame of the result gif
+        // u32 texel -> u8 \in {0, 1} (gif is a paletted format)
+        let pixels: Vec<u8> = bytemuck::cast_slice::<u8, u32>(&data as &[u8])
+            .iter()
+            .map(|&x| if x > 0 { 0u8 } else { 1u8 })
+            .collect();
+
+        let mut frame = gif::Frame::default();
+        frame.delay = 2;
+        frame.width = width as u16;
+        frame.height = height as u16;
+        frame.buffer = Cow::Borrowed(&*pixels);
+        gif_enc.write_frame(&frame).unwrap();
+
+        // (8.6) unmap the buffer to allow subsequent GPU writes to it
+        drop(data); // CPU pointer must not survive unmap (Rust memory safety guarantee)
+        staging_buffer.unmap();
+    }
+    bar.finish();
+
+    println!("Terminating the program ...")
+}
+
+/// (1) Initializing WebGPU
+async fn init_wgpu_device() -> Result<(wgpu::Device, wgpu::Queue), wgpu::RequestDeviceError> {
+    // Start an "Instance", which is the context for all things wgpu.
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        ..Default::default()
+    });
+
+    // An "Adapter" is a handle to a physical graphics/compute device.
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::default(), // None | LowPower | HighPerformance
+            compatible_surface: None,
+            force_fallback_adapter: false, // If needed to force CPU fallback?
+        })
+        .await
+        .unwrap();
+
+    // Request a connection to a physical device,
+    // and also access to the queue for its command buffers.
+    // It is possible, if necessary, to add a description of required features.
+    adapter.request_device(&Default::default(), None).await
+}
+
+// (2) Initialize a texture for the grid of cells.
+// Using u32 for storing boolean cell liveliness is a waste, but smaller format (e.g. u8) are
+// not allowed currently for storage textures.
+fn init_grid_texture(device: &wgpu::Device, width: u32, height: u32) -> wgpu::Texture {
+    let desc = wgpu::TextureDescriptor {
+        label: None,
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::R32Uint,
+        usage: wgpu::TextureUsages::COPY_DST
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::STORAGE_BINDING
+            | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[wgpu::TextureFormat::R32Uint],
+    };
+
+    device.create_texture(&desc)
+}
+
+/// (4) Initialize a staging buffer. Required because we can't retrieve the
+/// texture content directly when they're used as pipeline data.
+fn init_buffer(device: &wgpu::Device, width: u32, height: u32) -> wgpu::Buffer {
+    let desc = wgpu::BufferDescriptor {
+        label: None,
+        size: (width * height * 4).into(),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    };
+
+    device.create_buffer(&desc)
+}
+
+/// (6) Initialize a compute pipeline. Note how it requires a lot less settings compared
+/// to a render pipeline (less fixed functionalities to configure)
+fn build_pipeline(
+    device: &wgpu::Device,
+    shader_module: &wgpu::ShaderModule,
+    entry_point: &str,
+) -> wgpu::ComputePipeline {
+    let desc = wgpu::ComputePipelineDescriptor {
+        label: Some("Game of Life"),
+        layout: None,
+        module: shader_module,
+        entry_point,
+    };
+
+    device.create_compute_pipeline(&desc)
+}
+
+/// (8.1) Dispatch our compute shader into thread groups (aka workgroups), as many as required to cover the whole
+/// grid (thread per cell/texel)
+fn launch_kernel(
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::ComputePipeline,
+    grids_bind_group: &wgpu::BindGroup,
+    grid_size: &wgpu::Extent3d,
+) {
+    // Setup a compute pass
+    let desc = wgpu::ComputePassDescriptor {
+        label: None,
+        timestamp_writes: None,
+    };
+    let mut pass = encoder.begin_compute_pass(&desc);
+
+    pass.set_pipeline(&pipeline);
+    pass.set_bind_group(0, grids_bind_group, &[]);
+
+    // Workgroups are arranged in a 16x16 grid (as declared in the shader code),
+    // so we need to launch (width/16)x(height/16) of them
+    pass.dispatch_workgroups(grid_size.width / 16, grid_size.height / 16, 1);
+}
+
+/// (8.2) Copy the texture output into a buffer
+fn copy_texture_to_buffer(
+    encoder: &mut wgpu::CommandEncoder,
+    texture: &wgpu::Texture,
+    output_buffer: &wgpu::Buffer,
+) {
+    let texel_size = texture.format().block_copy_size(None).unwrap();
+    encoder.copy_texture_to_buffer(
+        // source
+        wgpu::ImageCopyTexture {
+            aspect: wgpu::TextureAspect::All,
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+        },
+        // destination
+        wgpu::ImageCopyBuffer {
+            buffer: &output_buffer,
+            layout: wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(texel_size * texture.width()),
+                rows_per_image: Some(texture.height()),
+            },
+        },
+        // copy_size
+        texture.size(),
+    );
+}
+
+/// (8.4) Retrieve the buffer data from the GPU
+async fn readback_buffer_data<'a>(
+    device: &wgpu::Device,
+    buffer: &'a wgpu::Buffer,
+) -> wgpu::BufferView<'a> {
+    let buffer_slice = buffer.slice(..);
+
+    // request the buffer to be mapped (made visible) to CPU memory
+    buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+
+    // block on the device until the mapping callback above is called (indicating completion)
+    device.poll(wgpu::Maintain::Wait);
+
+    // it's now safe to retrieve a pointer to the mapped memory
+    buffer_slice.get_mapped_range()
+}


### PR DESCRIPTION
The sample generates an animated gif of the evolution of a Game of Life automaton. The sample demonstrates:
* The use of a compute shader that writes into a storage texture
* The classic "ping-pong" technique between two textures for iterative computation
* The use of local workgroup memory (optional: see the shader code for details)
